### PR TITLE
fixed bug of overriding osseus objects instead of merging them (file conf & secrets conf)

### DIFF
--- a/index.js
+++ b/index.js
@@ -194,7 +194,7 @@ const init = function () {
           pid: pid
         }
       }
-      _.assign(result, envConf, fileConf, secretsConf, cliConf)
+      _.merge(result, envConf, fileConf, secretsConf, cliConf)
       result.keys = Object.keys(result)
       let keysWithOsseusPrefix = result.keys.filter(obj => {
         return obj.startsWith('osseus')


### PR DESCRIPTION
## Proposed changes
 
Fixed a bug causing file configurations of osseus objects to be overriden with secrets configuration of the same object instead of merging them

## Types of changes

What types of changes does your code introduce?
_Put an `x` in the boxes that apply_

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._

- [x] I have read the [CONTRIBUTING](https://github.com/colucom/osseus-config/blob/master/.github/CONTRIBUTING.md) doc
- [x] Lint and unit tests pass locally with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
- [ ] Any dependent changes have been merged and published in downstream modules